### PR TITLE
Use macos-11 for publish build.

### DIFF
--- a/.github/workflows/python-package-publish.yml
+++ b/.github/workflows/python-package-publish.yml
@@ -62,7 +62,7 @@ jobs:
   pypi_wheel_build:
     strategy:
       matrix:
-        os: ["ubuntu-latest", "macOS-10.15", "windows-2019"]
+        os: ["ubuntu-latest", "macOS-11", "windows-2019"]
     runs-on: ${{ matrix.os }}
     needs: [build_and_test]
     env:


### PR DESCRIPTION
The 10.15 action no longer works, so the auto-publish failed on the previous tag.