### PR TITLE
Update to modern numpy iteration API

### DIFF
--- a/hpgeom/hpgeom.c
+++ b/hpgeom/hpgeom.c
@@ -181,6 +181,10 @@ static PyObject *angle_to_pixel(PyObject *dummy, PyObject *args, PyObject *kwarg
         *outpix = ang2pix(&hpx, theta, phi);
     } while(iternext(iter));
 
+    // The reference to the automatically generated output array is owned
+    // by the iterator, so we must explicitly increase the reference
+    // count to keep it after deallocating the iterator. This is also the
+    // case for all uses following.
     pix_arr = (PyObject *)NpyIter_GetOperandArray(iter)[3];
     Py_INCREF(pix_arr);
 

--- a/hpgeom/hpgeom.c
+++ b/hpgeom/hpgeom.c
@@ -1775,6 +1775,7 @@ static PyObject *neighbors_meth(PyObject *dummy, PyObject *args, PyObject *kwarg
     int nest = 1;
     static char *kwlist[] = {"nside", "pix", "nest", NULL};
 
+    i64stack *neigh = NULL;
     int64_t *neighbor_pixels;
     healpix_info hpx;
     int status;
@@ -1823,7 +1824,7 @@ static PyObject *neighbors_meth(PyObject *dummy, PyObject *args, PyObject *kwarg
         scheme = RING;
     }
 
-    i64stack *neigh = i64stack_new(8, &status, err);
+    neigh = i64stack_new(8, &status, err);
     if (!status) {
         PyErr_SetString(PyExc_RuntimeError, err);
         goto fail;
@@ -1869,6 +1870,7 @@ static PyObject *neighbors_meth(PyObject *dummy, PyObject *args, PyObject *kwarg
     Py_DECREF(nside_arr);
     Py_DECREF(pix_arr);
     Py_DECREF(itr);
+    i64stack_delete(neigh);
 
     return PyArray_Return((PyArrayObject *)neighbor_arr);
 
@@ -1877,6 +1879,9 @@ fail:
     Py_XDECREF(pix_arr);
     Py_XDECREF(neighbor_arr);
     Py_XDECREF(itr);
+    if (neigh != NULL) {
+        i64stack_delete(neigh);
+    }
 
     return NULL;
 }

--- a/hpgeom/hpgeom.c
+++ b/hpgeom/hpgeom.c
@@ -55,12 +55,11 @@
     "    a resolution fact*nside. For nest ordering, fact must be a power\n" \
     "    of 2, and nside*fact must always be <= 2**29.  For ring ordering\n" \
     "    fact may be any positive integer.\n"
-#define RETURN_PIXEL_RANGES_PAR                                                   \
-    "return_pixel_ranges : `bool`, optional\n"                                    \
-    "    Return an array of pixel ranges instead of a list of pixels.\n"          \
-    "    The ranges will be sorted, and each range is of the form [lo, high).\n"  \
+#define RETURN_PIXEL_RANGES_PAR                                                  \
+    "return_pixel_ranges : `bool`, optional\n"                                   \
+    "    Return an array of pixel ranges instead of a list of pixels.\n"         \
+    "    The ranges will be sorted, and each range is of the form [lo, high).\n" \
     "    This option is only compatible with nest ordering.\n"
-
 
 PyDoc_STRVAR(angle_to_pixel_doc,
              "angle_to_pixel(nside, a, b, nest=True, lonlat=True, degrees=True)\n"
@@ -129,7 +128,8 @@ static PyObject *angle_to_pixel(PyObject *dummy, PyObject *args, PyObject *kwarg
     op_flags[3] = NPY_ITER_WRITEONLY | NPY_ITER_ALLOCATE;
     op_dtypes[3] = PyArray_DescrFromType(NPY_INT64);
 
-    iter = NpyIter_MultiNew(4, op, NPY_ITER_ZEROSIZE_OK, NPY_KEEPORDER, NPY_NO_CASTING, op_flags, op_dtypes);
+    iter = NpyIter_MultiNew(4, op, NPY_ITER_ZEROSIZE_OK, NPY_KEEPORDER, NPY_NO_CASTING,
+                            op_flags, op_dtypes);
     if (iter == NULL) {
         PyErr_SetString(PyExc_ValueError,
                         "nside, a, b arrays could not be broadcast together.");
@@ -179,7 +179,7 @@ static PyObject *angle_to_pixel(PyObject *dummy, PyObject *args, PyObject *kwarg
             phi = *b;
         }
         *outpix = ang2pix(&hpx, theta, phi);
-    } while(iternext(iter));
+    } while (iternext(iter));
 
     // The reference to the automatically generated output array is owned
     // by the iterator, so we must explicitly increase the reference
@@ -275,7 +275,8 @@ static PyObject *pixel_to_angle(PyObject *dummy, PyObject *args, PyObject *kwarg
     op_flags[3] = NPY_ITER_WRITEONLY | NPY_ITER_ALLOCATE;
     op_dtypes[3] = PyArray_DescrFromType(NPY_DOUBLE);
 
-    iter = NpyIter_MultiNew(4, op, NPY_ITER_ZEROSIZE_OK, NPY_KEEPORDER, NPY_NO_CASTING, op_flags, op_dtypes);
+    iter = NpyIter_MultiNew(4, op, NPY_ITER_ZEROSIZE_OK, NPY_KEEPORDER, NPY_NO_CASTING,
+                            op_flags, op_dtypes);
     if (iter == NULL) {
         PyErr_SetString(PyExc_ValueError,
                         "nside, pix arrays could not be broadcast together.");
@@ -319,13 +320,12 @@ static PyObject *pixel_to_angle(PyObject *dummy, PyObject *args, PyObject *kwarg
         if (lonlat) {
             // We can skip error checking since theta/phi will always be
             // within range on output.
-            hpgeom_thetaphi_to_lonlat(theta, phi, outa, outb,
-                                      (bool)degrees, false, err);
+            hpgeom_thetaphi_to_lonlat(theta, phi, outa, outb, (bool)degrees, false, err);
         } else {
             *outa = theta;
             *outb = phi;
         }
-    } while(iternext(iter));
+    } while (iternext(iter));
 
     a_arr = (PyObject *)NpyIter_GetOperandArray(iter)[2];
     Py_INCREF(a_arr);
@@ -358,15 +358,14 @@ fail:
 }
 
 static PyObject *create_query_return_arr(struct i64rangeset *pixset, int return_pixel_ranges,
-                                         int convert, healpix_info *hpx)
-{
+                                         int convert, healpix_info *hpx) {
     // Convenience routine to share code between query returns.
 
     PyObject *return_arr;
 
     if (return_pixel_ranges) {
         npy_intp dims[2];
-        dims[0] = pixset->stack->size/2;
+        dims[0] = pixset->stack->size / 2;
         dims[1] = 2;
 
         return_arr = PyArray_SimpleNew(2, dims, NPY_INT64);
@@ -396,7 +395,7 @@ static PyObject *create_query_return_arr(struct i64rangeset *pixset, int return_
 
     return return_arr;
 
- fail:
+fail:
     Py_XDECREF(return_arr);
 
     return NULL;
@@ -421,7 +420,7 @@ PyDoc_STRVAR(query_circle_doc,
              "    within the circle. If True, return all pixels that overlap with\n"
              "    the circle. This is an approximation and may return a few extra\n"
              "    pixels.\n" FACT_DOC_PAR NEST_DOC_PAR LONLAT_DOC_PAR DEGREES_DOC_PAR
-             RETURN_PIXEL_RANGES_PAR
+                 RETURN_PIXEL_RANGES_PAR
              "\n"
              "Returns\n"
              "-------\n"
@@ -455,7 +454,8 @@ static PyObject *query_circle(PyObject *dummy, PyObject *args, PyObject *kwargs)
     int degrees = 1;
     int return_pixel_ranges = 0;
     static char *kwlist[] = {"nside", "a",    "b",      "radius",  "inclusive",
-                             "fact",  "nest", "lonlat", "degrees", "return_pixel_ranges", NULL};
+                             "fact",  "nest", "lonlat", "degrees", "return_pixel_ranges",
+                             NULL};
 
     char err[ERR_SIZE];
     int status = 1;
@@ -467,7 +467,8 @@ static PyObject *query_circle(PyObject *dummy, PyObject *args, PyObject *kwargs)
         goto fail;
 
     if (return_pixel_ranges & ~nest) {
-        PyErr_SetString(PyExc_RuntimeError, "Can only use return_pixel_ranges with nest ordering.");
+        PyErr_SetString(PyExc_RuntimeError,
+                        "Can only use return_pixel_ranges with nest ordering.");
         goto fail;
     }
 
@@ -556,7 +557,7 @@ PyDoc_STRVAR(query_polygon_doc,
              "    within the polygon. If True, return all pixels that overlap with\n"
              "    the polygon. This is an approximation and may return a few extra\n"
              "    pixels.\n" FACT_DOC_PAR NEST_DOC_PAR LONLAT_DOC_PAR DEGREES_DOC_PAR
-             RETURN_PIXEL_RANGES_PAR
+                 RETURN_PIXEL_RANGES_PAR
              "\n"
              "Returns\n"
              "-------\n"
@@ -591,20 +592,21 @@ static PyObject *query_polygon_meth(PyObject *dummy, PyObject *args, PyObject *k
     int lonlat = 1;
     int degrees = 1;
     int return_pixel_ranges = 0;
-    static char *kwlist[] = {"nside", "a",      "b",       "inclusive", "fact",
+    static char *kwlist[] = {"nside", "a",      "b",       "inclusive",           "fact",
                              "nest",  "lonlat", "degrees", "return_pixel_ranges", NULL};
     char err[ERR_SIZE];
     int status = 1;
     i64rangeset *pixset = NULL;
     pointingarr *vertices = NULL;
 
-    if (!PyArg_ParseTupleAndKeywords(args, kwargs, "LOO|plpppp", kwlist, &nside, &a_obj, &b_obj,
-                                     &inclusive, &fact, &nest, &lonlat, &degrees,
+    if (!PyArg_ParseTupleAndKeywords(args, kwargs, "LOO|plpppp", kwlist, &nside, &a_obj,
+                                     &b_obj, &inclusive, &fact, &nest, &lonlat, &degrees,
                                      &return_pixel_ranges))
         goto fail;
 
     if (return_pixel_ranges & ~nest) {
-        PyErr_SetString(PyExc_RuntimeError, "Can only use return_pixel_ranges with nest ordering.");
+        PyErr_SetString(PyExc_RuntimeError,
+                        "Can only use return_pixel_ranges with nest ordering.");
         goto fail;
     }
 
@@ -748,7 +750,7 @@ PyDoc_STRVAR(query_ellipse_doc,
              "    within the ellipse. If True, return all pixels that overlap with\n"
              "    the ellipse. This is an approximation and may return a few extra\n"
              "    pixels.\n" FACT_DOC_PAR NEST_DOC_PAR LONLAT_DOC_PAR DEGREES_DOC_PAR
-             RETURN_PIXEL_RANGES_PAR
+                 RETURN_PIXEL_RANGES_PAR
              "\n"
              "Returns\n"
              "-------\n"
@@ -784,9 +786,9 @@ static PyObject *query_ellipse_meth(PyObject *dummy, PyObject *args, PyObject *k
     int lonlat = 1;
     int degrees = 1;
     int return_pixel_ranges = 0;
-    static char *kwlist[] = {"nside",     "a",    "b",    "semi_major", "semi_minor", "alpha",
-                             "inclusive", "fact", "nest", "lonlat",     "degrees",
-                             "return_pixel_ranges", NULL};
+    static char *kwlist[] = {
+        "nside", "a",    "b",      "semi_major", "semi_minor",          "alpha", "inclusive",
+        "fact",  "nest", "lonlat", "degrees",    "return_pixel_ranges", NULL};
 
     char err[ERR_SIZE];
     int status = 1;
@@ -798,7 +800,8 @@ static PyObject *query_ellipse_meth(PyObject *dummy, PyObject *args, PyObject *k
         goto fail;
 
     if (return_pixel_ranges & ~nest) {
-        PyErr_SetString(PyExc_RuntimeError, "Can only use return_pixel_ranges with nest ordering.");
+        PyErr_SetString(PyExc_RuntimeError,
+                        "Can only use return_pixel_ranges with nest ordering.");
         goto fail;
     }
 
@@ -895,7 +898,7 @@ PyDoc_STRVAR(
     "    within the box. If True, return all pixels that overlap with\n"
     "    the box. This is an approximation and may return a few extra\n"
     "    pixels.\n" FACT_DOC_PAR NEST_DOC_PAR LONLAT_DOC_PAR DEGREES_DOC_PAR
-    RETURN_PIXEL_RANGES_PAR
+        RETURN_PIXEL_RANGES_PAR
     "\n"
     "Returns\n"
     "-------\n"
@@ -930,8 +933,18 @@ static PyObject *query_box_meth(PyObject *dummy, PyObject *args, PyObject *kwarg
     int lonlat = 1;
     int degrees = 1;
     int return_pixel_ranges = 0;
-    static char *kwlist[] = {"nside", "a0",   "a1",     "b0",      "b1", "inclusive",
-                             "fact",  "nest", "lonlat", "degrees", "return_pixel_ranges", NULL};
+    static char *kwlist[] = {"nside",
+                             "a0",
+                             "a1",
+                             "b0",
+                             "b1",
+                             "inclusive",
+                             "fact",
+                             "nest",
+                             "lonlat",
+                             "degrees",
+                             "return_pixel_ranges",
+                             NULL};
 
     char err[ERR_SIZE];
     int status = 1;
@@ -943,7 +956,8 @@ static PyObject *query_box_meth(PyObject *dummy, PyObject *args, PyObject *kwarg
         goto fail;
 
     if (return_pixel_ranges & ~nest) {
-        PyErr_SetString(PyExc_RuntimeError, "Can only use return_pixel_ranges with nest ordering.");
+        PyErr_SetString(PyExc_RuntimeError,
+                        "Can only use return_pixel_ranges with nest ordering.");
         goto fail;
     }
 
@@ -1090,7 +1104,8 @@ static PyObject *nest_to_ring(PyObject *dummy, PyObject *args, PyObject *kwargs)
     op_flags[2] = NPY_ITER_WRITEONLY | NPY_ITER_ALLOCATE;
     op_dtypes[2] = PyArray_DescrFromType(NPY_INT64);
 
-    iter = NpyIter_MultiNew(3, op, NPY_ITER_ZEROSIZE_OK, NPY_KEEPORDER, NPY_NO_CASTING, op_flags, op_dtypes);
+    iter = NpyIter_MultiNew(3, op, NPY_ITER_ZEROSIZE_OK, NPY_KEEPORDER, NPY_NO_CASTING,
+                            op_flags, op_dtypes);
     if (iter == NULL) {
         PyErr_SetString(PyExc_ValueError,
                         "nside, pix arrays could not be broadcast together.");
@@ -1123,7 +1138,7 @@ static PyObject *nest_to_ring(PyObject *dummy, PyObject *args, PyObject *kwargs)
             goto fail;
         }
         *ring_pix = nest2ring(&hpx, *nest_pix);
-    } while(iternext(iter));
+    } while (iternext(iter));
 
     ring_pix_arr = (PyObject *)NpyIter_GetOperandArray(iter)[2];
     Py_INCREF(ring_pix_arr);
@@ -1208,7 +1223,8 @@ static PyObject *ring_to_nest(PyObject *dummy, PyObject *args, PyObject *kwargs)
     op_flags[2] = NPY_ITER_WRITEONLY | NPY_ITER_ALLOCATE;
     op_dtypes[2] = PyArray_DescrFromType(NPY_INT64);
 
-    iter = NpyIter_MultiNew(3, op, NPY_ITER_ZEROSIZE_OK, NPY_KEEPORDER, NPY_NO_CASTING, op_flags, op_dtypes);
+    iter = NpyIter_MultiNew(3, op, NPY_ITER_ZEROSIZE_OK, NPY_KEEPORDER, NPY_NO_CASTING,
+                            op_flags, op_dtypes);
     if (iter == NULL) {
         PyErr_SetString(PyExc_ValueError,
                         "nside, pix arrays could not be broadcast together.");
@@ -1241,7 +1257,7 @@ static PyObject *ring_to_nest(PyObject *dummy, PyObject *args, PyObject *kwargs)
             goto fail;
         }
         *nest_pix = ring2nest(&hpx, *ring_pix);
-    } while(iternext(iter));
+    } while (iternext(iter));
 
     nest_pix_arr = (PyObject *)NpyIter_GetOperandArray(iter)[2];
     Py_INCREF(nest_pix_arr);
@@ -1345,7 +1361,8 @@ static PyObject *boundaries_meth(PyObject *dummy, PyObject *args, PyObject *kwar
     op_flags[1] = NPY_ITER_READONLY;
     op_dtypes[1] = NULL;
 
-    iter = NpyIter_MultiNew(2, op, NPY_ITER_ZEROSIZE_OK, NPY_KEEPORDER, NPY_NO_CASTING, op_flags, op_dtypes);
+    iter = NpyIter_MultiNew(2, op, NPY_ITER_ZEROSIZE_OK, NPY_KEEPORDER, NPY_NO_CASTING,
+                            op_flags, op_dtypes);
     if (iter == NULL) {
         PyErr_SetString(PyExc_ValueError,
                         "nside, pix arrays could not be broadcast together.");
@@ -1430,7 +1447,7 @@ static PyObject *boundaries_meth(PyObject *dummy, PyObject *args, PyObject *kwar
             }
         }
 
-    } while(iternext(iter));
+    } while (iternext(iter));
 
     Py_DECREF(nside_arr);
     Py_DECREF(pix_arr);
@@ -1528,7 +1545,8 @@ static PyObject *vector_to_pixel(PyObject *dummy, PyObject *args, PyObject *kwar
     op_flags[4] = NPY_ITER_WRITEONLY | NPY_ITER_ALLOCATE;
     op_dtypes[4] = PyArray_DescrFromType(NPY_INT64);
 
-    iter = NpyIter_MultiNew(5, op, NPY_ITER_ZEROSIZE_OK, NPY_KEEPORDER, NPY_NO_CASTING, op_flags, op_dtypes);
+    iter = NpyIter_MultiNew(5, op, NPY_ITER_ZEROSIZE_OK, NPY_KEEPORDER, NPY_NO_CASTING,
+                            op_flags, op_dtypes);
     if (iter == NULL) {
         PyErr_SetString(PyExc_ValueError,
                         "nside, x, y, z arrays could not be broadcast together.");
@@ -1570,7 +1588,7 @@ static PyObject *vector_to_pixel(PyObject *dummy, PyObject *args, PyObject *kwar
         vec.y = *y;
         vec.z = *z;
         *outpix = vec2pix(&hpx, &vec);
-    } while(iternext(iter));
+    } while (iternext(iter));
 
     pix_arr = (PyObject *)NpyIter_GetOperandArray(iter)[4];
     Py_INCREF(pix_arr);
@@ -1669,7 +1687,8 @@ static PyObject *pixel_to_vector(PyObject *dummy, PyObject *args, PyObject *kwar
     op_flags[4] = NPY_ITER_WRITEONLY | NPY_ITER_ALLOCATE;
     op_dtypes[4] = PyArray_DescrFromType(NPY_DOUBLE);
 
-    iter = NpyIter_MultiNew(5, op, NPY_ITER_ZEROSIZE_OK, NPY_KEEPORDER, NPY_NO_CASTING, op_flags, op_dtypes);
+    iter = NpyIter_MultiNew(5, op, NPY_ITER_ZEROSIZE_OK, NPY_KEEPORDER, NPY_NO_CASTING,
+                            op_flags, op_dtypes);
     if (iter == NULL) {
         PyErr_SetString(PyExc_ValueError,
                         "nside, x, y, z arrays could not be broadcast together.");
@@ -1715,7 +1734,7 @@ static PyObject *pixel_to_vector(PyObject *dummy, PyObject *args, PyObject *kwar
         *x = vec.x;
         *y = vec.y;
         *z = vec.z;
-    } while(iternext(iter));
+    } while (iternext(iter));
 
     x_arr = (PyObject *)NpyIter_GetOperandArray(iter)[2];
     Py_INCREF(x_arr);
@@ -1821,7 +1840,8 @@ static PyObject *neighbors_meth(PyObject *dummy, PyObject *args, PyObject *kwarg
     op_flags[1] = NPY_ITER_READONLY;
     op_dtypes[1] = NULL;
 
-    iter = NpyIter_MultiNew(2, op, NPY_ITER_ZEROSIZE_OK, NPY_KEEPORDER, NPY_NO_CASTING, op_flags, op_dtypes);
+    iter = NpyIter_MultiNew(2, op, NPY_ITER_ZEROSIZE_OK, NPY_KEEPORDER, NPY_NO_CASTING,
+                            op_flags, op_dtypes);
     if (iter == NULL) {
         PyErr_SetString(PyExc_ValueError,
                         "nside, pix arrays could not be broadcast together.");
@@ -1891,7 +1911,7 @@ static PyObject *neighbors_meth(PyObject *dummy, PyObject *args, PyObject *kwarg
             index = neigh->size * NpyIter_GetIterIndex(iter) + i;
             neighbor_pixels[index] = neigh->data[i];
         }
-    } while(iternext(iter));
+    } while (iternext(iter));
 
     Py_DECREF(nside_arr);
     Py_DECREF(pix_arr);
@@ -1967,7 +1987,8 @@ static PyObject *max_pixel_radius(PyObject *dummy, PyObject *args, PyObject *kwa
     op_flags[1] = NPY_ITER_WRITEONLY | NPY_ITER_ALLOCATE;
     op_dtypes[1] = PyArray_DescrFromType(NPY_DOUBLE);
 
-    iter = NpyIter_MultiNew(2, op, NPY_ITER_ZEROSIZE_OK, NPY_KEEPORDER, NPY_NO_CASTING, op_flags, op_dtypes);
+    iter = NpyIter_MultiNew(2, op, NPY_ITER_ZEROSIZE_OK, NPY_KEEPORDER, NPY_NO_CASTING,
+                            op_flags, op_dtypes);
     if (iter == NULL) {
         PyErr_SetString(PyExc_ValueError,
                         "nside, a, b arrays could not be broadcast together.");
@@ -1996,7 +2017,7 @@ static PyObject *max_pixel_radius(PyObject *dummy, PyObject *args, PyObject *kwa
         *pixrad = max_pixrad(&hpx);
         if (degrees) *pixrad *= HPG_R2D;
 
-    } while(iternext(iter));
+    } while (iternext(iter));
 
     pixrad_arr = (PyObject *)NpyIter_GetOperandArray(iter)[1];
     Py_INCREF(pixrad_arr);
@@ -2095,7 +2116,8 @@ static PyObject *get_interpolation_weights(PyObject *dummy, PyObject *args, PyOb
     op_flags[2] = NPY_ITER_READONLY;
     op_dtypes[2] = NULL;
 
-    iter = NpyIter_MultiNew(3, op, NPY_ITER_ZEROSIZE_OK, NPY_KEEPORDER, NPY_NO_CASTING, op_flags, op_dtypes);
+    iter = NpyIter_MultiNew(3, op, NPY_ITER_ZEROSIZE_OK, NPY_KEEPORDER, NPY_NO_CASTING,
+                            op_flags, op_dtypes);
     if (iter == NULL) {
         PyErr_SetString(PyExc_ValueError,
                         "nside, a, b arrays could not be broadcast together.");
@@ -2165,7 +2187,7 @@ static PyObject *get_interpolation_weights(PyObject *dummy, PyObject *args, PyOb
         }
         size_t index = 4 * NpyIter_GetIterIndex(iter);
         get_interpol(&hpx, theta, phi, &pixels[index], &weights[index]);
-    } while(iternext(iter));
+    } while (iternext(iter));
 
     Py_DECREF(nside_arr);
     Py_DECREF(a_arr);
@@ -2218,15 +2240,18 @@ static PyObject *pixel_ranges_to_pixels(PyObject *dummy, PyObject *args, PyObjec
     static char *kwlist[] = {"pixel_ranges", "inclusive", NULL};
     NpyIter *iter = NULL;
     NpyIter_IterNextFunc *iternext;
-    char** dataptr;
+    char **dataptr;
 
-    if (!PyArg_ParseTupleAndKeywords(args, kwargs, "O|p", kwlist, &pixel_ranges_obj, &inclusive))
+    if (!PyArg_ParseTupleAndKeywords(args, kwargs, "O|p", kwlist, &pixel_ranges_obj,
+                                     &inclusive))
         goto fail;
 
-    pixel_ranges_arr = PyArray_FROM_OTF(pixel_ranges_obj, NPY_INT64, NPY_ARRAY_IN_ARRAY | NPY_ARRAY_ENSUREARRAY);
+    pixel_ranges_arr = PyArray_FROM_OTF(pixel_ranges_obj, NPY_INT64,
+                                        NPY_ARRAY_IN_ARRAY | NPY_ARRAY_ENSUREARRAY);
     if (pixel_ranges_arr == NULL) goto fail;
 
-    if ((PyArray_NDIM((PyArrayObject *)pixel_ranges_arr) != 2) || (PyArray_DIM((PyArrayObject *)pixel_ranges_arr, 1) != 2)) {
+    if ((PyArray_NDIM((PyArrayObject *)pixel_ranges_arr) != 2) ||
+        (PyArray_DIM((PyArrayObject *)pixel_ranges_arr, 1) != 2)) {
         PyErr_SetString(PyExc_ValueError, "pixel_ranges must be 2D, with shape (M, 2).");
         goto fail;
     }
@@ -2242,18 +2267,14 @@ static PyObject *pixel_ranges_to_pixels(PyObject *dummy, PyObject *args, PyObjec
     }
 
     iter = NpyIter_New((PyArrayObject *)pixel_ranges_arr,
-                       NPY_ITER_READONLY | NPY_ITER_MULTI_INDEX,
-                       NPY_KEEPORDER,
-                       NPY_NO_CASTING,
+                       NPY_ITER_READONLY | NPY_ITER_MULTI_INDEX, NPY_KEEPORDER, NPY_NO_CASTING,
                        NULL);
     if (iter == NULL) goto fail;
     // We don't want to iterate over the second axis.
-    if (NpyIter_RemoveAxis(iter, 1) == NPY_FAIL)
-        goto fail;
+    if (NpyIter_RemoveAxis(iter, 1) == NPY_FAIL) goto fail;
 
     iternext = NpyIter_GetIterNext(iter, NULL);
-    if (iternext == NULL)
-        goto fail;
+    if (iternext == NULL) goto fail;
 
     dataptr = NpyIter_GetDataPtrArray(iter);
 
@@ -2263,10 +2284,11 @@ static PyObject *pixel_ranges_to_pixels(PyObject *dummy, PyObject *args, PyObjec
     dims[0] = 0;
 
     do {
-        int64_t* data = (int64_t *) *dataptr;
+        int64_t *data = (int64_t *)*dataptr;
 
         if (*(data + 1) < *data) {
-            PyErr_SetString(PyExc_ValueError, "pixel_ranges[:, 0] must all be <= pixel_ranges[:, 1]");
+            PyErr_SetString(PyExc_ValueError,
+                            "pixel_ranges[:, 0] must all be <= pixel_ranges[:, 1]");
             goto fail;
         }
 
@@ -2280,31 +2302,28 @@ static PyObject *pixel_ranges_to_pixels(PyObject *dummy, PyObject *args, PyObjec
     int64_t *pix_data = (int64_t *)PyArray_DATA((PyArrayObject *)pix_arr);
 
     // Reset the iterator and loop to expand pixels.
-    if (NpyIter_Reset(iter, NULL) == NPY_FAIL)
-        goto fail;
+    if (NpyIter_Reset(iter, NULL) == NPY_FAIL) goto fail;
 
     size_t counter = 0;
 
     do {
-        int64_t* data = (int64_t *) *dataptr;
+        int64_t *data = (int64_t *)*dataptr;
 
         for (int64_t pix = *data; pix < (*(data + 1) + inclusive); pix++) {
             pix_data[counter++] = pix;
         }
     } while (iternext(iter));
 
- succeed:
+succeed:
 
     Py_DECREF(pixel_ranges_arr);
-    if (iter != NULL)
-        NpyIter_Deallocate(iter);
+    if (iter != NULL) NpyIter_Deallocate(iter);
 
     return PyArray_Return((PyArrayObject *)pix_arr);
 
- fail:
+fail:
     Py_XDECREF(pixel_ranges_arr);
-    if (iter != NULL)
-        NpyIter_Deallocate(iter);
+    if (iter != NULL) NpyIter_Deallocate(iter);
     Py_XDECREF(pix_arr);
 
     return NULL;

--- a/hpgeom/hpgeom.c
+++ b/hpgeom/hpgeom.c
@@ -1168,10 +1168,11 @@ static PyObject *ring_to_nest(PyObject *dummy, PyObject *args, PyObject *kwargs)
     PyObject *nside_obj = NULL, *ring_pix_obj = NULL;
     PyObject *nside_arr = NULL, *ring_pix_arr = NULL;
     PyObject *nest_pix_arr = NULL;
-    PyArrayMultiIterObject *itr = NULL;
+
+    NpyIter *iter = NULL;
+
     static char *kwlist[] = {"nside", "pix", NULL};
 
-    int64_t *nest_pix_data = NULL;
     healpix_info hpx;
     char err[ERR_SIZE];
 
@@ -1185,24 +1186,43 @@ static PyObject *ring_to_nest(PyObject *dummy, PyObject *args, PyObject *kwargs)
         PyArray_FROM_OTF(ring_pix_obj, NPY_INT64, NPY_ARRAY_IN_ARRAY | NPY_ARRAY_ENSUREARRAY);
     if (ring_pix_arr == NULL) goto fail;
 
-    itr = (PyArrayMultiIterObject *)PyArray_MultiIterNew(2, nside_arr, ring_pix_arr);
-    if (itr == NULL) {
+    // The input arrays are nside_arr (int64_t) and ring_pix_arr (int64_t).
+    // The output array is nest_pix_arr (int64_t).
+    PyArrayObject *op[3];
+    npy_uint32 op_flags[3];
+    PyArray_Descr *op_dtypes[3];
+    NpyIter_IterNextFunc *iternext;
+    char **dataptrarray;
+
+    op[0] = (PyArrayObject *)nside_arr;
+    op_flags[0] = NPY_ITER_READONLY;
+    op_dtypes[0] = NULL;
+    op[1] = (PyArrayObject *)ring_pix_arr;
+    op_flags[1] = NPY_ITER_READONLY;
+    op_dtypes[1] = NULL;
+    op[2] = (PyArrayObject *)nest_pix_arr;
+    op_flags[2] = NPY_ITER_WRITEONLY | NPY_ITER_ALLOCATE;
+    op_dtypes[2] = PyArray_DescrFromType(NPY_INT64);
+
+    iter = NpyIter_MultiNew(3, op, NPY_ITER_ZEROSIZE_OK, NPY_KEEPORDER, NPY_NO_CASTING, op_flags, op_dtypes);
+    if (iter == NULL) {
         PyErr_SetString(PyExc_ValueError,
                         "nside, pix arrays could not be broadcast together.");
         goto fail;
     }
 
-    nest_pix_arr = PyArray_SimpleNew(itr->nd, itr->dimensions, NPY_INT64);
-    if (nest_pix_arr == NULL) goto fail;
-    nest_pix_data = (int64_t *)PyArray_DATA((PyArrayObject *)nest_pix_arr);
+    iternext = NpyIter_GetIterNext(iter, NULL);
+    dataptrarray = NpyIter_GetDataPtrArray(iter);
 
     int64_t *nside;
     int64_t *ring_pix;
+    int64_t *nest_pix;
     int64_t last_nside = -1;
     bool started = false;
-    while (PyArray_MultiIter_NOTDONE(itr)) {
-        nside = (int64_t *)PyArray_MultiIter_DATA(itr, 0);
-        ring_pix = (int64_t *)PyArray_MultiIter_DATA(itr, 1);
+    do {
+        nside = (int64_t *)dataptrarray[0];
+        ring_pix = (int64_t *)dataptrarray[1];
+        nest_pix = (int64_t *)dataptrarray[2];
 
         if ((!started) || (*nside != last_nside)) {
             if (!hpgeom_check_nside(*nside, NEST, err)) {
@@ -1216,13 +1236,18 @@ static PyObject *ring_to_nest(PyObject *dummy, PyObject *args, PyObject *kwargs)
             PyErr_SetString(PyExc_ValueError, err);
             goto fail;
         }
-        nest_pix_data[itr->index] = ring2nest(&hpx, *ring_pix);
-        PyArray_MultiIter_NEXT(itr);
-    }
+        *nest_pix = ring2nest(&hpx, *ring_pix);
+    } while(iternext(iter));
+
+    nest_pix_arr = (PyObject *)NpyIter_GetOperandArray(iter)[2];
+    Py_INCREF(nest_pix_arr);
 
     Py_DECREF(nside_arr);
     Py_DECREF(ring_pix_arr);
-    Py_DECREF(itr);
+    if (NpyIter_Deallocate(iter) != NPY_SUCCEED) {
+        iter = NULL;
+        goto fail;
+    }
 
     return PyArray_Return((PyArrayObject *)nest_pix_arr);
 
@@ -1230,7 +1255,9 @@ fail:
     Py_XDECREF(nside_arr);
     Py_XDECREF(ring_pix_arr);
     Py_XDECREF(nest_pix_arr);
-    Py_XDECREF(itr);
+    if (iter != NULL) {
+        NpyIter_Deallocate(iter);
+    }
 
     return NULL;
 }

--- a/hpgeom/hpgeom.c
+++ b/hpgeom/hpgeom.c
@@ -1351,8 +1351,8 @@ static PyObject *boundaries_meth(PyObject *dummy, PyObject *args, PyObject *kwar
     iternext = NpyIter_GetIterNext(iter, NULL);
     dataptrarray = NpyIter_GetDataPtrArray(iter);
 
-    int ndims_pix = PyArray_NDIM((PyArrayObject *)pix_arr);
-    if (ndims_pix == 0) {
+    int ndims = NpyIter_GetNDim(iter);
+    if (ndims == 0) {
         npy_intp dims[1];
         dims[0] = 4 * step;
         a_arr = PyArray_SimpleNew(1, dims, NPY_FLOAT64);
@@ -1361,7 +1361,7 @@ static PyObject *boundaries_meth(PyObject *dummy, PyObject *args, PyObject *kwar
         if (b_arr == NULL) goto fail;
     } else {
         npy_intp dims[2];
-        dims[0] = PyArray_DIM((PyArrayObject *)pix_arr, 0);
+        dims[0] = NpyIter_GetIterSize(iter);
         dims[1] = 4 * step;
         a_arr = PyArray_SimpleNew(2, dims, NPY_FLOAT64);
         if (a_arr == NULL) goto fail;

--- a/hpgeom/hpgeom.c
+++ b/hpgeom/hpgeom.c
@@ -1482,7 +1482,6 @@ static PyObject *vector_to_pixel(PyObject *dummy, PyObject *args, PyObject *kwar
     int nest = 1;
     static char *kwlist[] = {"nside", "x", "y", "z", "nest", NULL};
 
-    int64_t *pixels = NULL;
     healpix_info hpx;
     char err[ERR_SIZE];
 

--- a/tests/test_angle_to_pixel.py
+++ b/tests/test_angle_to_pixel.py
@@ -90,6 +90,7 @@ def test_angle_to_pixel_scalar(nside):
     pix_scalar1 = hpgeom.angle_to_pixel(nside, lon[0], lat[0], nest=True, lonlat=True, degrees=True)
 
     assert pix_scalar1 == pix_arr[0]
+    assert not isinstance(pix_scalar1, np.ndarray)
 
     pix_scalar2 = hpgeom.angle_to_pixel(
         nside,
@@ -100,6 +101,7 @@ def test_angle_to_pixel_scalar(nside):
         degrees=True
     )
 
+    assert not isinstance(pix_scalar2, np.ndarray)
     assert pix_scalar2 == pix_arr[0]
 
 

--- a/tests/test_boundaries.py
+++ b/tests/test_boundaries.py
@@ -57,7 +57,7 @@ def test_boundaries_single(nside, pixfrac, step, scheme):
 @pytest.mark.parametrize("scheme", ["nest", "ring"])
 @pytest.mark.parametrize("npix", [1, 5])
 def test_boundaries_multiple(nside, pixfrac, step, scheme, npix):
-    """Test boundaries, single pixel."""
+    """Test boundaries, multiple pixels."""
     pixels = np.array([int(pixfrac*hpgeom.nside_to_npixel(nside))]*npix)
     if (scheme == "nest"):
         nest = True
@@ -103,6 +103,24 @@ def test_boundaries_multiple(nside, pixfrac, step, scheme, npix):
     )
     np.testing.assert_array_almost_equal(lonrad_hpgeom, np.deg2rad(lon_healpy))
     np.testing.assert_array_almost_equal(latrad_hpgeom, np.deg2rad(lat_healpy))
+
+
+def test_boundaries_multiple_nside():
+    """Test boundaries, multiple nside."""
+    lon, lat = hpgeom.boundaries([1024, 2048], [100, 200])
+    assert lon.shape == (2, 4)
+    assert lat.shape == (2, 4)
+
+    lon1, lat1 = hpgeom.boundaries(1024, 100)
+    np.testing.assert_array_equal(lon[0, :], lon1)
+    np.testing.assert_array_equal(lat[0, :], lat1)
+    lon2, lat2 = hpgeom.boundaries(2048, 200)
+    np.testing.assert_array_equal(lon[1, :], lon2)
+    np.testing.assert_array_equal(lat[1, :], lat2)
+
+    lon3, lat3 = hpgeom.boundaries([1024, 2048], 100)
+    assert lon3.shape == (2, 4)
+    assert lat3.shape == (2, 4)
 
 
 def test_boundaries_bad_inputs():

--- a/tests/test_interpolation.py
+++ b/tests/test_interpolation.py
@@ -113,6 +113,28 @@ def test_interpolation_scalar(nside):
     np.testing.assert_array_almost_equal(interp_wgt_scalar, interp_wgt[0, :])
 
 
+def test_interpolation_multiple_nside():
+    """Test interpolation, multiple nside."""
+    interp_pix, interp_wgt = hpgeom.get_interpolation_weights(
+        [1024, 2048],
+        [1.0, 2.0],
+        [1.0, 2.0],
+    )
+    assert interp_pix.shape == (2, 4)
+    assert interp_wgt.shape == (2, 4)
+
+    interp_pix1, interp_wgt1 = hpgeom.get_interpolation_weights(1024, 1.0, 1.0)
+    np.testing.assert_array_equal(interp_pix[0, :], interp_pix1)
+    np.testing.assert_array_equal(interp_wgt[0, :], interp_wgt1)
+    interp_pix2, interp_wgt2 = hpgeom.get_interpolation_weights(2048, 2.0, 2.0)
+    np.testing.assert_array_equal(interp_pix[1, :], interp_pix2)
+    np.testing.assert_array_equal(interp_wgt[1, :], interp_wgt2)
+
+    interp_pix3, interp_wgt3 = hpgeom.get_interpolation_weights([1024, 2048], 1.0, 1.0)
+    assert interp_pix3.shape == (2, 4)
+    assert interp_wgt3.shape == (2, 4)
+
+
 def test_interpolation_mismatched_dims():
     """Test get_interpolation_weights when dimensions are mismatched."""
     np.random.seed(12345)

--- a/tests/test_max_pixel_radius.py
+++ b/tests/test_max_pixel_radius.py
@@ -34,6 +34,17 @@ def test_max_pixel_radius(degrees):
     np.testing.assert_almost_equal(radius_hpgeom, radius_healpy)
 
 
+def test_max_pixel_radius_scalar():
+    """Test max_pixel_radius with a scalar."""
+    nsides = 2**np.arange(29)
+
+    radii_arr = hpgeom.max_pixel_radius(nsides)
+    radius_scalar = hpgeom.max_pixel_radius(nsides[0])
+
+    assert radius_scalar == radii_arr[0]
+    assert not isinstance(radius_scalar, np.ndarray)
+
+
 def test_max_pixel_radius_badinputs():
     """Test max_pixel_radius with bad inputs."""
     with pytest.raises(ValueError, match=r"nside .* must be positive"):

--- a/tests/test_neighbors.py
+++ b/tests/test_neighbors.py
@@ -30,6 +30,29 @@ def test_neighbors(nside, scheme):
     np.testing.assert_array_equal(neighbors_hpgeom, neighbors_healpy)
 
 
+def test_neighbors_single_pixel():
+    """Test neighbors, single pixel."""
+    neighbors = hpgeom.neighbors(1024, 100)
+    assert neighbors.shape == (8, )
+
+    neighbors2 = hpgeom.neighbors(1024, [100, 200])
+    np.testing.assert_array_equal(neighbors, neighbors2[0, :])
+
+
+def test_neighbors_multiple_nside():
+    """Test neighbors, multiple nside."""
+    neighbors = hpgeom.neighbors([1024, 2048], [100, 200])
+    assert neighbors.shape == (2, 8)
+
+    neighbors2_1 = hpgeom.neighbors(1024, 100)
+    np.testing.assert_array_equal(neighbors[0, :], neighbors2_1)
+    neighbors2_2 = hpgeom.neighbors(2048, 200)
+    np.testing.assert_array_equal(neighbors[1, :], neighbors2_2)
+
+    neighbors3 = hpgeom.neighbors([1024, 2048], 100)
+    assert neighbors3.shape == (2, 8)
+
+
 def test_neighbors_bad_input():
     """Test neighbors, bad input."""
     with pytest.raises(ValueError, match=r"Pixel value .* out of range"):

--- a/tests/test_nest_to_ring.py
+++ b/tests/test_nest_to_ring.py
@@ -37,6 +37,24 @@ def test_nest_to_ring_samplepix(nside):
 
 
 @pytest.mark.parametrize("nside", [2**0, 2**5, 2**10, 2**15, 2**20, 2**25, 2**29])
+def test_nest_to_ring_scalar(nside):
+    """Test nest_to_ring for scalars."""
+    np.random.seed(12345)
+
+    nest_pix = np.random.randint(low=0, high=12*nside*nside-1, size=100, dtype=np.int64)
+    ring_arr = hpgeom.nest_to_ring(nside, nest_pix)
+    ring_scalar = hpgeom.nest_to_ring(nside, nest_pix[0])
+
+    assert ring_scalar == ring_arr[0]
+    assert not isinstance(ring_scalar, np.ndarray)
+
+    ring_scalar2 = hpgeom.nest_to_ring(nside, int(nest_pix[0]))
+
+    assert ring_scalar2 == ring_arr[0]
+    assert not isinstance(ring_scalar2, np.ndarray)
+
+
+@pytest.mark.parametrize("nside", [2**0, 2**5, 2**10, 2**15, 2**20, 2**25, 2**29])
 def test_nest_to_ring_bad_pix(nside):
     """Test nest_to_ring errors when given bad pixel"""
 

--- a/tests/test_pixel_ranges.py
+++ b/tests/test_pixel_ranges.py
@@ -59,6 +59,18 @@ def test_pixel_ranges_empty():
     assert len(pixels) == 0
 
 
+def test_pixel_ranges_scalar():
+    """Test pixel ranges, scalar."""
+    range1 = np.zeros((1, 2), dtype=np.int64)
+    range1[0, 0] = 100
+    range1[0, 1] = 101
+
+    pixels = hpg.pixel_ranges_to_pixels(range1)
+
+    assert pixels == 100
+    assert len(pixels) == 1
+
+
 def test_pixel_ranges_bad():
     """Test pixel_ranges_to_pixels, bad inputs."""
     with pytest.raises(ValueError, match=r"pixel_ranges must be 2D"):

--- a/tests/test_pixel_to_angle.py
+++ b/tests/test_pixel_to_angle.py
@@ -86,6 +86,8 @@ def test_pixel_to_angle_scalar(nside):
 
     assert lon_scalar1 == lon_arr[0]
     assert lat_scalar1 == lat_arr[0]
+    assert not isinstance(lon_scalar1, np.ndarray)
+    assert not isinstance(lat_scalar1, np.ndarray)
 
     lon_scalar2, lat_scalar2 = hpgeom.pixel_to_angle(
         nside,
@@ -97,6 +99,8 @@ def test_pixel_to_angle_scalar(nside):
 
     assert lon_scalar2 == lon_arr[0]
     assert lat_scalar2 == lat_arr[0]
+    assert not isinstance(lon_scalar2, np.ndarray)
+    assert not isinstance(lat_scalar2, np.ndarray)
 
 
 @pytest.mark.parametrize("nside", [2**0, 2**5, 2**10, 2**15, 2**20, 2**25, 2**29])

--- a/tests/test_pixel_to_vector.py
+++ b/tests/test_pixel_to_vector.py
@@ -33,6 +33,23 @@ def test_pixel_to_vector(nside, scheme):
 
 
 @pytest.mark.parametrize("nside", [2**0, 2**5, 2**10, 2**15, 2**20, 2**25, 2**29])
+def test_pixel_to_vector_scalar(nside):
+    np.random.seed(12345)
+
+    pix = np.random.randint(low=0, high=hpgeom.nside_to_npixel(nside) - 1, size=100, dtype=np.int64)
+
+    x_arr, y_arr, z_arr = hpgeom.pixel_to_vector(nside, pix)
+    x_scalar, y_scalar, z_scalar = hpgeom.pixel_to_vector(nside, pix[0])
+
+    assert x_scalar == x_arr[0]
+    assert y_scalar == y_arr[0]
+    assert z_scalar == z_arr[0]
+    assert not isinstance(x_scalar, np.ndarray)
+    assert not isinstance(y_scalar, np.ndarray)
+    assert not isinstance(z_scalar, np.ndarray)
+
+
+@pytest.mark.parametrize("nside", [2**0, 2**5, 2**10, 2**15, 2**20, 2**25, 2**29])
 def test_pixel_to_vector_bad_pix(nside):
     """Test pixel_to_angle errors when given bad pixel"""
 

--- a/tests/test_ring_to_nest.py
+++ b/tests/test_ring_to_nest.py
@@ -37,6 +37,24 @@ def test_ring_to_nest_samplepix(nside):
 
 
 @pytest.mark.parametrize("nside", [2**0, 2**5, 2**10, 2**15, 2**20, 2**25, 2**29])
+def test_ring_to_nest_scalar(nside):
+    """Test ring_to_nest for scalars."""
+    np.random.seed(12345)
+
+    ring_pix = np.random.randint(low=0, high=12*nside*nside-1, size=100, dtype=np.int64)
+    nest_arr = hpgeom.ring_to_nest(nside, ring_pix)
+    nest_scalar = hpgeom.ring_to_nest(nside, ring_pix[0])
+
+    assert nest_scalar == nest_arr[0]
+    assert not isinstance(nest_scalar, np.ndarray)
+
+    nest_scalar2 = hpgeom.ring_to_nest(nside, int(ring_pix[0]))
+
+    assert nest_scalar2 == nest_arr[0]
+    assert not isinstance(nest_scalar2, np.ndarray)
+
+
+@pytest.mark.parametrize("nside", [2**0, 2**5, 2**10, 2**15, 2**20, 2**25, 2**29])
 def test_ring_to_nest_bad_pix(nside):
     """Test ring_to_nest errors when given bad pixel"""
 

--- a/tests/test_vector_to_pixel.py
+++ b/tests/test_vector_to_pixel.py
@@ -32,8 +32,8 @@ def test_vector_to_pixel(nside, scheme):
     np.testing.assert_array_equal(pix_hpgeom, pix_healpy)
 
 
-def test_vector_to_pixel_single():
-    """Test vector_to_pixel, single pixel."""
+def test_vector_to_pixel_scalar():
+    """Test vector_to_pixel, scalar pixel."""
     x = 0.5
     y = 0.5
     z = 0.5
@@ -41,3 +41,4 @@ def test_vector_to_pixel_single():
     pix_hpgeom = hpgeom.vector_to_pixel(1024, x, y, z)
 
     assert isinstance(pix_hpgeom, np.int64)
+    assert not isinstance(pix_hpgeom, np.ndarray)


### PR DESCRIPTION
Originally I had (erroneously) used the old iteration API, and this updates to the new API.

At the same time I realized that there were missing tests for (a) ensuring scalars are handled correctly; (b) ensuring multiple nsides are handled correctly.  Many of these new tests fail for the code on main prior to this PR.