### PR TITLE
Add support for hpgeom to be used in multithreading situations

### DIFF
--- a/.github/workflows/python-package-pr.yml
+++ b/.github/workflows/python-package-pr.yml
@@ -27,13 +27,13 @@ jobs:
             python-version: "3.11"
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         # Need to clone everything to determine version from git.
         fetch-depth: 0
 
     - name: Set up Python
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
         cache: "pip"

--- a/.github/workflows/python-package-pr.yml
+++ b/.github/workflows/python-package-pr.yml
@@ -15,16 +15,16 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest ]
-        python-version: ['3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.10', '3.11', '3.12', '3.13']
         include:
+          # This gives us x86
+          - os: macos-15-intel
+            python-version: "3.11"
           # This gives us arm64
           - os: macos-latest
-            python-version: "3.11"
-          # This gives us x86
-          - os: macos-13
-            python-version: "3.11"
+            python-version: "3.13"
           - os: windows-latest
-            python-version: "3.11"
+            python-version: "3.13"
 
     steps:
     - uses: actions/checkout@v6

--- a/.github/workflows/python-package-publish.yml
+++ b/.github/workflows/python-package-publish.yml
@@ -10,13 +10,13 @@ jobs:
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/')
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           # Need to clone everything to determine version from git.
           fetch-depth: 0
 
       - name: Set up Python
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v6
         with:
           python-version: "3.10"
           cache: "pip"
@@ -43,7 +43,7 @@ jobs:
           fetch-depth: 0
 
       - name: Set up Python
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v6
         with:
           python-version: "3.10"
           cache: "pip"
@@ -55,7 +55,7 @@ jobs:
       - name: Build and create distribution
         run: |
             python -m build --sdist
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v6
         with:
           path: dist/*
 
@@ -71,13 +71,13 @@ jobs:
       CIBW_ARCHS_LINUX: "auto"
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           # Need to clone everything to embed the versiona
           fetch-depth: 0
 
       - name: Set up Python
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v6
         with:
           python-version: "3.10"
           cache: "pip"
@@ -89,7 +89,7 @@ jobs:
       - name: Build and create distribution
         run: |
           python -m cibuildwheel --output-dir dist
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v6
         with:
           path: dist/*
 
@@ -98,7 +98,7 @@ jobs:
     runs-on: ubuntu-latest
     environment: Publish
     steps:
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v7
         with:
           name: artifact
           path: dist

--- a/.github/workflows/python-package-publish.yml
+++ b/.github/workflows/python-package-publish.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: "3.10"
+          python-version: "3.13"
           cache: "pip"
           cache-dependency-path: "setup.cfg"
 
@@ -45,7 +45,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: "3.10"
+          python-version: "3.13"
           cache: "pip"
           cache-dependency-path: "setup.cfg"
 
@@ -62,11 +62,11 @@ jobs:
   pypi_wheel_build:
     strategy:
       matrix:
-        os: ["ubuntu-latest", "macOS-12", "windows-2019"]
+        os: ["ubuntu-latest", "macOS-15", "windows-2022"]
     runs-on: ${{ matrix.os }}
     needs: [build_and_test]
     env:
-      CIBW_BUILD: "cp3{9,10,11,12}-{manylinux_x86_64,macosx_arm64,macosx_x86_64,win_amd64}"
+      CIBW_BUILD: "cp3{10,11,12,13}-{manylinux_x86_64,macosx_arm64,macosx_x86_64,win_amd64}"
       CIBW_ARCHS_MACOS: "x86_64 arm64"
       CIBW_ARCHS_LINUX: "auto"
 
@@ -79,7 +79,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: "3.10"
+          python-version: "3.13"
           cache: "pip"
           cache-dependency-path: "setup.cfg"
 

--- a/.github/workflows/python-package-push.yml
+++ b/.github/workflows/python-package-push.yml
@@ -19,13 +19,13 @@ jobs:
         os: [ubuntu-latest]
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         # Need to clone everything to determine version from git.
         fetch-depth: 0
 
     - name: Set up Python
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
         cache: "pip"


### PR DESCRIPTION
This does not add multithreading to hpgeom.  Rather, it allows the GIL to be released so that it may be used effectively if threading is turned on.